### PR TITLE
feat: iOS Reminders integration for date fields in row edit

### DIFF
--- a/artifacts/mobile/app.json
+++ b/artifacts/mobile/app.json
@@ -29,7 +29,14 @@
       ],
       "expo-font",
       "expo-web-browser",
-      "expo-secure-store"
+      "expo-secure-store",
+      [
+        "expo-calendar",
+        {
+          "calendarPermission": "Allow $(PRODUCT_NAME) to access your calendar.",
+          "remindersPermission": "Allow $(PRODUCT_NAME) to access your reminders so you can set due date alerts from row date fields."
+        }
+      ]
     ],
     "experiments": {
       "typedRoutes": true,

--- a/artifacts/mobile/app/(app)/row/[tableId]/[rowId].tsx
+++ b/artifacts/mobile/app/(app)/row/[tableId]/[rowId].tsx
@@ -246,6 +246,7 @@ export default function EditRowScreen() {
                 key={f.id}
                 field={f}
                 value={values[f.name]}
+                reminderKey={`${tableId}_${rowId}_${f.id}`}
                 onChange={(next) => {
                   setValues((prev) => ({ ...prev, [f.name]: next }));
                   setDirty(true);

--- a/artifacts/mobile/components/FieldInput.tsx
+++ b/artifacts/mobile/components/FieldInput.tsx
@@ -18,6 +18,7 @@ import {
 import { FileFieldInput } from "@/components/FileFieldInput";
 import { LinkRowFieldInput } from "@/components/LinkRowFieldInput";
 import { useColors } from "@/hooks/useColors";
+import { useReminders } from "@/hooks/useReminders";
 import {
   dateToBaserowString,
   isEditable,
@@ -29,9 +30,10 @@ type FieldInputProps = {
   field: BaserowField;
   value: unknown;
   onChange: (next: unknown) => void;
+  reminderKey?: string;
 };
 
-export function FieldInput({ field, value, onChange }: FieldInputProps) {
+export function FieldInput({ field, value, onChange, reminderKey }: FieldInputProps) {
   const colors = useColors();
   const editable = isEditable(field);
 
@@ -297,7 +299,7 @@ export function FieldInput({ field, value, onChange }: FieldInputProps) {
     return (
       <View style={styles.group}>
         {labelRow}
-        <DateField field={field} value={value} onChange={onChange} />
+        <DateField field={field} value={value} onChange={onChange} reminderKey={reminderKey} />
       </View>
     );
   }
@@ -376,9 +378,10 @@ type DateFieldProps = {
   field: BaserowField;
   value: unknown;
   onChange: (next: unknown) => void;
+  reminderKey?: string;
 };
 
-function DateField({ field, value, onChange }: DateFieldProps) {
+function DateField({ field, value, onChange, reminderKey }: DateFieldProps) {
   const colors = useColors();
   const includeTime = Boolean(field.date_include_time);
   const current = parseBaserowDate(value);
@@ -398,7 +401,47 @@ function DateField({ field, value, onChange }: DateFieldProps) {
       includeTime={includeTime}
       date={current}
       onChange={(d) => onChange(d ? dateToBaserowString(d, includeTime) : null)}
+      reminderKey={reminderKey}
+      fieldName={field.name}
     />
+  );
+}
+
+function ReminderButton({
+  fieldName,
+  date,
+  reminderKey,
+}: {
+  fieldName: string;
+  date: Date;
+  reminderKey: string;
+}) {
+  const colors = useColors();
+  const { hasReminder, saveReminder } = useReminders(reminderKey);
+
+  return (
+    <Pressable
+      onPress={() => {
+        Haptics.selectionAsync().catch(() => {});
+        saveReminder(fieldName, date).catch(() => {});
+      }}
+      hitSlop={8}
+      style={[
+        styles.clearBtn,
+        {
+          backgroundColor: hasReminder ? colors.primary : colors.muted,
+          borderColor: hasReminder ? colors.primary : colors.border,
+          borderRadius: colors.radius,
+        },
+      ]}
+      testID="reminder-btn"
+    >
+      <Feather
+        name="bell"
+        size={16}
+        color={hasReminder ? colors.primaryForeground : colors.mutedForeground}
+      />
+    </Pressable>
   );
 }
 
@@ -406,10 +449,14 @@ function NativeDateInput({
   includeTime,
   date,
   onChange,
+  reminderKey,
+  fieldName,
 }: {
   includeTime: boolean;
   date: Date | null;
   onChange: (d: Date | null) => void;
+  reminderKey?: string;
+  fieldName?: string;
 }) {
   const colors = useColors();
   const [showDate, setShowDate] = useState(false);
@@ -487,6 +534,13 @@ function NativeDateInput({
           >
             <Feather name="x" size={16} color={colors.mutedForeground} />
           </Pressable>
+        ) : null}
+        {date && reminderKey && fieldName && Platform.OS === "ios" ? (
+          <ReminderButton
+            fieldName={fieldName}
+            date={date}
+            reminderKey={reminderKey}
+          />
         ) : null}
       </View>
 

--- a/artifacts/mobile/hooks/useReminders.ts
+++ b/artifacts/mobile/hooks/useReminders.ts
@@ -1,0 +1,92 @@
+import * as Calendar from "expo-calendar";
+import * as SecureStore from "expo-secure-store";
+import { useCallback, useEffect, useState } from "react";
+import { Alert, Platform } from "react-native";
+
+const MAP_KEY = "baserow_reminder_ids";
+
+async function loadReminderMap(): Promise<Record<string, string>> {
+  try {
+    const raw = await SecureStore.getItemAsync(MAP_KEY);
+    return raw ? (JSON.parse(raw) as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+async function saveReminderMap(map: Record<string, string>): Promise<void> {
+  try {
+    await SecureStore.setItemAsync(MAP_KEY, JSON.stringify(map));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+export function useReminders(key: string | undefined) {
+  const isSupported = Platform.OS === "ios";
+  const [hasReminder, setHasReminder] = useState(false);
+
+  useEffect(() => {
+    if (!isSupported || !key) return;
+    loadReminderMap().then((map) => setHasReminder(Boolean(map[key])));
+  }, [key, isSupported]);
+
+  const saveReminder = useCallback(
+    async (title: string, dueDate: Date): Promise<void> => {
+      if (!isSupported || !key) return;
+
+      const { status } = await Calendar.requestRemindersPermissionsAsync();
+      if (status !== "granted") {
+        Alert.alert(
+          "Reminders Access Required",
+          "Please allow Reminders access in your device Settings to use this feature.",
+        );
+        return;
+      }
+
+      const calendars = await Calendar.getCalendarsAsync(
+        Calendar.EntityTypes.REMINDER,
+      );
+      const remList =
+        calendars.find((c) => c.allowsModifications) ?? calendars[0];
+      if (!remList) {
+        Alert.alert("No Reminders List", "Could not find a Reminders list.");
+        return;
+      }
+
+      const map = await loadReminderMap();
+      const existingId = map[key];
+
+      if (existingId) {
+        try {
+          await Calendar.updateReminderAsync(existingId, {
+            title,
+            dueDate,
+            completed: false,
+          });
+          setHasReminder(true);
+          Alert.alert(
+            "Reminder Updated",
+            `"${title}" has been updated in Reminders.`,
+          );
+          return;
+        } catch {
+          // Reminder was deleted externally; fall through to create a new one
+        }
+      }
+
+      const reminderId = await Calendar.createReminderAsync(remList.id, {
+        title,
+        dueDate,
+        completed: false,
+      });
+      map[key] = reminderId;
+      await saveReminderMap(map);
+      setHasReminder(true);
+      Alert.alert("Reminder Added", `"${title}" added to Reminders.`);
+    },
+    [key, isSupported],
+  );
+
+  return { isSupported, hasReminder, saveReminder };
+}

--- a/artifacts/mobile/package.json
+++ b/artifacts/mobile/package.json
@@ -57,6 +57,7 @@
   },
   "dependencies": {
     "@react-native-community/datetimepicker": "8.4.5",
+    "expo-calendar": "~14.0.0",
     "expo-document-picker": "~14.0.8",
     "expo-secure-store": "~15.0.8",
     "react-native-markdown-display": "^7.0.2"


### PR DESCRIPTION
Closes #23

Adds iOS Reminders integration to date fields in the row edit screen. When a date/time is set on a date field, a bell icon appears next to the date picker (iOS only). Tapping it creates or updates an iOS Reminder with the field name as title and the selected date as due date.

## Changes
- New `hooks/useReminders.ts` — permission, create/update via expo-calendar, persist IDs via expo-secure-store
- `ReminderButton` component in `FieldInput.tsx` (iOS-only, next to the clear button on date fields)
- `reminderKey` threaded through `FieldInput` — `DateField` — `NativeDateInput`
- Row edit screen passes `tableId_rowId_fieldId` as the reminder key
- `expo-calendar ~14.0.0` added to package.json
- expo-calendar config plugin added to app.json

Generated with [Claude Code](https://claude.ai/code)